### PR TITLE
Removing trailing slashes from package.json file to prevent JSON pars…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "owl",
         "semantic web",
         "ringo",
-        "bio-ontology",
+        "bio-ontology"
     ],
     "author": "Chris Mungall <cjmungall@lbl.gov>",
     "contributors": [
@@ -34,7 +34,7 @@
     },
     "bin": {
         "owljs" : "bin/owljs",
-        "owljs-repl.js" : "bin/owljs-repl.js",
+        "owljs-repl.js" : "bin/owljs-repl.js"
     },
     "main": "lib/owl.js"
 }


### PR DESCRIPTION
…ing error

No longer fails with this error:
SEVERE: Could not parse package.json file:/Users/jseide/Sites/owljs/package.json
java.lang.RuntimeException: org.mozilla.javascript.json.JsonParser$ParseException: Unexpected comma in array literal